### PR TITLE
This commit represents a comprehensive overhaul of the presale websit…

### DIFF
--- a/src/components/AboutSection.tsx
+++ b/src/components/AboutSection.tsx
@@ -7,10 +7,10 @@ const AboutSection: React.FC = () => {
         <h2 className="text-3xl font-bold text-gray-800 mb-6">
           Welcome to <span className="text-orange-600">SolarCrowdin</span>
         </h2>
-        <p className="text-lg text-gray-600 mb-4">
+        <p className="text-lg text-gray-800 dark:text-solar-grey mb-4">
           At SolarCrowdin, we are not just building solar projects; we are using AI to power a cleaner, smarter future.
         </p>
-        <p className="text-lg text-gray-600">
+        <p className="text-lg text-gray-800 dark:text-solar-grey">
           Our platform combines Artificial Intelligence, Blockchain, and Renewable Energy to deliver transparent, efficient, and scalable clean energy and forestation solutions. With Artificial Intelligence at the core, we predict energy needs, optimize solar systems, and verify carbon credits in real-time, ensuring impact for communities and trust for investors.
         </p>
         <p className="mt-4 font-semibold text-orange-600">

--- a/src/components/BreakingNews.tsx
+++ b/src/components/BreakingNews.tsx
@@ -25,14 +25,14 @@ const BreakingNews = () => {
   };
 
   return (
-    <div className="fixed top-16 w-full z-30 bg-gradient-to-r from-orange-500 to-yellow-500 text-white font-bold py-2 overflow-hidden">
-      <div className="flex items-center whitespace-nowrap">
-        <span className="flex-shrink-0 mx-4 pr-16 flex items-center">
-            <FiZap className="mr-2"/>
-            BREAKING NEWS
-        </span>
+    <div className="fixed top-16 w-full z-30 bg-gradient-to-r from-orange-500 to-yellow-500 text-white font-bold py-2 flex items-center">
+      <span className="flex-shrink-0 mx-4 flex items-center z-10">
+          <FiZap className="mr-2"/>
+          BREAKING NEWS
+      </span>
+      <div className="flex-1 overflow-hidden">
         <motion.div
-          className="flex"
+          className="flex whitespace-nowrap"
           variants={marqueeVariants}
           animate="animate"
         >

--- a/src/components/HowToBuy.tsx
+++ b/src/components/HowToBuy.tsx
@@ -57,7 +57,7 @@ const HowToBuy = () => {
               </div>
             </div>
             <h4 className="font-semibold text-gray-800 dark:text-solar-warm-white mb-2">{step.title}</h4>
-            <p className="text-sm text-gray-600 dark:text-solar-grey">{step.description}</p>
+            <p className="text-sm text-gray-800 dark:text-solar-grey">{step.description}</p>
           </div>
         ))}
       </div>

--- a/src/components/PresaleCountdown.tsx
+++ b/src/components/PresaleCountdown.tsx
@@ -15,19 +15,19 @@ const PresaleCountdown = ({ timeLeft }: PresaleCountdownProps) => {
     <div className="mt-6 flex justify-center space-x-4 bg-gray-50/80 rounded-lg p-4">
       <div className="text-center">
         <div className="text-2xl font-bold text-orange-600">{timeLeft.days}</div>
-        <div className="text-sm text-gray-600 font-medium">Days</div>
+        <div className="text-sm text-gray-800 dark:text-solar-grey font-medium">Days</div>
       </div>
       <div className="text-center">
         <div className="text-2xl font-bold text-orange-600">{timeLeft.hours}</div>
-        <div className="text-sm text-gray-600 font-medium">Hours</div>
+        <div className="text-sm text-gray-800 dark:text-solar-grey font-medium">Hours</div>
       </div>
       <div className="text-center">
         <div className="text-2xl font-bold text-orange-600">{timeLeft.minutes}</div>
-        <div className="text-sm text-gray-600 font-medium">Minutes</div>
+        <div className="text-sm text-gray-800 dark:text-solar-grey font-medium">Minutes</div>
       </div>
       <div className="text-center">
         <div className="text-2xl font-bold text-orange-600">{timeLeft.seconds}</div>
-        <div className="text-sm text-gray-600 font-medium">Seconds</div>
+        <div className="text-sm text-gray-800 dark:text-solar-grey font-medium">Seconds</div>
       </div>
     </div>
   );

--- a/src/components/TopHolders.tsx
+++ b/src/components/TopHolders.tsx
@@ -21,7 +21,7 @@ const TopHolders = () => {
             </div>
             <div className="text-right">
               <p className="font-bold text-orange-600 dark:text-solar-gold">+{tier.bonus}%</p>
-              <p className="text-sm text-gray-600 dark:text-solar-grey">Bonus Tokens</p>
+              <p className="text-sm text-gray-800 dark:text-solar-grey">Bonus Tokens</p>
             </div>
           </div>
         ))}

--- a/src/hooks/usePresale.ts
+++ b/src/hooks/usePresale.ts
@@ -111,7 +111,9 @@ export function usePresale() {
 
       // Simulate dynamic data from contract
       const currentTime = Math.floor(Date.now() / 1000);
-      const endTime = new Date('2025-09-10T00:00:00Z').getTime() / 1000;
+      const futureDate = new Date();
+      futureDate.setMonth(futureDate.getMonth() + 3);
+      const endTime = Math.floor(futureDate.getTime() / 1000);
       
       // Dynamic values that change over time
       const baseTime = Math.floor(Date.now() / 1000);

--- a/src/pages/FAQ.tsx
+++ b/src/pages/FAQ.tsx
@@ -71,13 +71,13 @@ const FAQ: React.FC = () => {
   ];
 
   return (
-    <div className="min-h-screen bg-white pt-20">
+    <div className="min-h-screen bg-white dark:bg-black pt-20">
       <div className="max-w-4xl mx-auto px-4 py-16">
         <div className="text-center mb-12">
-          <h1 className="text-4xl md:text-5xl font-extrabold text-gray-900 mb-4">
-            Frequently Asked <span className="text-orange-600">Questions</span>
+          <h1 className="text-4xl md:text-5xl font-extrabold text-gray-900 dark:text-solar-warm-white mb-4">
+            Frequently Asked <span className="nebulae-text">Questions</span>
           </h1>
-          <p className="text-lg text-gray-600">
+          <p className="text-lg text-gray-800 dark:text-solar-grey">
             Everything you need to know about the SolarCrowdin ICO and our mission.
           </p>
         </div>
@@ -85,10 +85,10 @@ const FAQ: React.FC = () => {
         <Accordion type="single" collapsible className="w-full">
           {faqs.map((faq, index) => (
             <AccordionItem key={index} value={`item-${index}`}>
-              <AccordionTrigger className="text-left font-semibold text-lg hover:no-underline">
+              <AccordionTrigger className="text-left font-semibold text-lg hover:no-underline text-gray-900 dark:text-solar-warm-white">
                 {faq.question}
               </AccordionTrigger>
-              <AccordionContent className="text-gray-600 text-base">
+              <AccordionContent className="text-gray-800 dark:text-solar-grey text-base">
                 {faq.answer}
               </AccordionContent>
             </AccordionItem>


### PR DESCRIPTION
…e, incorporating multiple rounds of user feedback to align the application with the project's vision and branding.

The key achievements of this work include:

### Core Logic & Content Overhaul
- **Tokenomics:** The entire tokenomics model was updated to a 1 billion fixed supply, with detailed distribution, vesting schedules, and a new revenue allocation model (35/35/30 split).
- **Blockchain Identity:** Corrected all frontend references to reflect the project's status as a BEP-20 token on the BNB Smart Chain.
- **Content Update:** The About, Features, and FAQ sections have been completely rewritten with new, professional content focusing on the project's value proposition, including its use of AI, dMRV, and its mission in emerging markets.
- **Presale Timer:** The countdown timer was fixed and reset to a 3-month timeline.

### UI/UX Enhancements & Bug Fixes
- **Theme Implementation:** A full light/dark/system theme switcher has been implemented. The base theme has been restored to the original "solar-nebulae" design, with a new AMOLED black dark mode.
- **UI Unification:** All card components have been restyled to be consistent with the user's preferred design, creating a cohesive and professional look and feel.
- **New Components:** A "Breaking News" scrolling bar has been added.
- **Bug Fixes:**
  - Resolved issues with the news bar (text overlap, scroll speed).
  - Fixed input field text visibility across themes.
  - Synchronized the two different presale counters to a single data source.
  - Addressed layout issues, such as the news bar overlapping the navbar.

### Code Health
- **Dependency Management:** Updated OpenZeppelin contract dependencies and fixed related import path issues.
- **Code Cleanup:** Removed dead components (`VIPStatus.tsx`).

This series of changes transforms the website into a professional, visually consistent, and functionally correct platform that accurately reflects the SolarCrowdin project.